### PR TITLE
Adding Additional Fonts for bodhi and dzongkha

### DIFF
--- a/bod/okfonts.txt
+++ b/bod/okfonts.txt
@@ -4,4 +4,5 @@ Kailasa Regular
 Kokonor Regular
 Tibetan Machine Uni Regular
 TibetanTsugRing Regular
-Microsoft Himalaya
+Microsoft Himalaya Regular
+Amne Regular

--- a/bod/okfonts.txt
+++ b/bod/okfonts.txt
@@ -4,3 +4,4 @@ Kailasa Regular
 Kokonor Regular
 Tibetan Machine Uni Regular
 TibetanTsugRing Regular
+Microsoft Himalaya

--- a/dzo/okfonts.txt
+++ b/dzo/okfonts.txt
@@ -3,3 +3,5 @@ Jomolhari Regular
 Kailasa Regular
 Kokonor Regular
 Tibetan Machine Uni Regular
+Microsoft Himalaya Regular 
+Amne Regular


### PR DESCRIPTION
Add Micrsoft Himalaya font present in ms word and Amne Regular which is the default in macos for writing tibetan